### PR TITLE
Updated the README to cache badges for 1 hour (was 30 days before)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <p align="center"><img style="padding:10px;" src="https://img.shields.io/badge/Open%20Source-💕%20-9cf?style=for-the-badge"></p>
 
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com) [![GitHub pull-requests](https://img.shields.io/github/issues-pr/farQtech/Data-Structures.svg)](https://GitHub.com/farQtech/Data-Structures/pull/)
- [![GitHub issues](https://img.shields.io/github/issues/farQtech/Data-Structures.svg)](https://GitHub.com/farQtech/Data-Structures/issues/)
- [![GitHub forks](https://img.shields.io/github/forks/farQtech/Data-Structures.svg?style=social&label=Fork&maxAge=2592000)](https://GitHub.com/farQtech/Data-Structures/network/)
- [![GitHub stars](https://img.shields.io/github/stars/farQtech/Data-Structures.svg?style=social&label=Star&maxAge=2592000)](https://GitHub.com/farQtech/Data-Structures/stargazers/)
- [![GitHub watchers](https://img.shields.io/github/watchers/farQtech/Data-Structures.svg?style=social&label=Watch&maxAge=2592000)](https://GitHub.com/farQtech/Data-Structures/watchers/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com) [![GitHub pull-requests](https://img.shields.io/github/issues-pr/farQtech/Data-Structures.svg)](https://github.com/farQtech/Data-Structures/pull/)
+ [![GitHub issues](https://img.shields.io/github/issues/farQtech/Data-Structures.svg)](https://github.com/farQtech/Data-Structures/issues/)
+ [![GitHub forks](https://img.shields.io/github/forks/farQtech/Data-Structures.svg?style=social&label=Fork&cacheSeconds=3600)](https://github.com/farQtech/Data-Structures/network/)
+ [![GitHub stars](https://img.shields.io/github/stars/farQtech/Data-Structures.svg?style=social&label=Star&cacheSeconds=3600)](https://github.com/farQtech/Data-Structures/stargazers/)
+ [![GitHub watchers](https://img.shields.io/github/watchers/farQtech/Data-Structures.svg?style=social&label=Watch&cacheSeconds=3600)](https://github.com/farQtech/Data-Structures/watchers/)
 
 # Data-Structures
 


### PR DESCRIPTION
Will fix the bug in issue #23

- `maxAge=2592000` = `2592000` seconds = `30` days
- `maxAge` is the legacy name for the parameter (and it's still supported), but the new name is ` cacheSeconds` so I changed that too